### PR TITLE
Update FreeRDP-Testing-Manual.markdown

### DIFF
--- a/Testing/FreeRDP-Testing-Manual.markdown
+++ b/Testing/FreeRDP-Testing-Manual.markdown
@@ -8,7 +8,7 @@
 
 [FreeRDP User Manual](https://github.com/awakecoding/FreeRDP-Manuals/blob/master/User/FreeRDP-User-Manual.pdf?raw=true "FreeRDP User Manual")
 
-[FreeRDP Developer Manual](https://github.com/awakecoding/FreeRDP-Manuals/blob/master/Configuration/FreeRDP-Developer-Manual.pdf?raw=true "FreeRDP Developer Manual")
+[FreeRDP Developer Manual](https://github.com/awakecoding/FreeRDP-Manuals/blob/master/Developer/FreeRDP-Developer-Manual.pdf?raw=true "FreeRDP Developer Manual")
 
 [FreeRDP Configuration Manual](https://github.com/awakecoding/FreeRDP-Manuals/blob/master/Configuration/FreeRDP-Configuration-Manual.pdf?raw=true "FreeRDP Configuration Manual")
 


### PR DESCRIPTION
Fixed the developer manual's URL
