### PR TITLE
Update FreeRDP-Configuration-Manual.markdown

### DIFF
--- a/Configuration/FreeRDP-Configuration-Manual.markdown
+++ b/Configuration/FreeRDP-Configuration-Manual.markdown
@@ -14,7 +14,7 @@ To be expanded.
 
 [FreeRDP User Manual](https://github.com/awakecoding/FreeRDP-Manuals/blob/master/User/FreeRDP-User-Manual.pdf?raw=true "FreeRDP User Manual")
 
-[FreeRDP Developer Manual](https://github.com/awakecoding/FreeRDP-Manuals/blob/master/Configuration/FreeRDP-Developer-Manual.pdf?raw=true "FreeRDP Developer Manual")
+[FreeRDP Developer Manual](https://raw.githubusercontent.com/awakecoding/FreeRDP-Manuals/master/Developer/FreeRDP-Developer-Manual.pdf?raw=true "FreeRDP Developer Manual")
 
 [FreeRDP Testing Manual](https://github.com/awakecoding/FreeRDP-Manuals/blob/master/Testing/FreeRDP-Testing-Manual.pdf?raw=true "FreeRDP Testing Manual")
 


### PR DESCRIPTION
Fix the issue of 404 error regarding the link of developer manual.
I just changed the hyperlink of developer manual.